### PR TITLE
Use skyeysnow.com for skyeysnow because it is supported in pure IPv6 environment

### DIFF
--- a/ptsites/sites/skyey2.py
+++ b/ptsites/sites/skyey2.py
@@ -7,7 +7,7 @@ from ..utils.google_auth import GoogleAuth
 
 
 class MainClass(Discuz):
-    URL = 'https://www.skyey2.com/'
+    URL = 'https://skyeysnow.com/'
     USER_CLASSES = {
         'points': [1000000]
     }


### PR DESCRIPTION
www.skyey2.com isn't associated with an AAAA DNS record, but skyeysnow.com is.