### PR TITLE
Remove unnecessary output

### DIFF
--- a/ptsites/schema/site_base.py
+++ b/ptsites/schema/site_base.py
@@ -311,7 +311,6 @@ class SiteBase:
             entry['result'] = SignState.SUCCEED.value
             return SignState.SUCCEED
         if not isinstance(succeed_regex, list):
-            print(succeed_regex)
             succeed_regex = [succeed_regex]
 
         for regex in succeed_regex:

--- a/ptsites/schema/unit3d.py
+++ b/ptsites/schema/unit3d.py
@@ -61,5 +61,4 @@ class Unit3D(SiteBase):
         return value.replace(' ', '')
 
     def handle_join_date(self, value):
-        print(value)
         return parse(value).date()


### PR DESCRIPTION
以下代码已经输出了正则表达式的匹配部分，因此没有必要输出原始正则表达式
https://github.com/madwind/flexget_qbittorrent_mod/blob/44a9511532b87f9d80ac122d09aa255ce2e8105a/ptsites/schema/site_base.py#L322
https://github.com/madwind/flexget_qbittorrent_mod/blob/44a9511532b87f9d80ac122d09aa255ce2e8105a/ptsites/executor.py#L64-L65