### PR TITLE
fix hdpost

### DIFF
--- a/ptsites/sites/hdpost.py
+++ b/ptsites/sites/hdpost.py
@@ -63,7 +63,7 @@ class MainClass(Unit3D):
                 url='/login',
                 method='password',
                 check_state=('network', NetworkState.SUCCEED),
-                response_urls=[''],
+                response_urls=['', '/pages/1'],
                 token_regex=r'(?<=name="_token" value=").+?(?=")',
                 captcha_regex=r'(?<=name="_captcha" value=").+?(?=")',
             )

--- a/ptsites/sites/hdpost.py
+++ b/ptsites/sites/hdpost.py
@@ -63,7 +63,7 @@ class MainClass(Unit3D):
                 url='/login',
                 method='password',
                 check_state=('network', NetworkState.SUCCEED),
-                response_urls=['/pages/1'],
+                response_urls=[''],
                 token_regex=r'(?<=name="_token" value=").+?(?=")',
                 captcha_regex=r'(?<=name="_captcha" value=").+?(?=")',
             )


### PR DESCRIPTION
```
2022-05-10 19:39:45 ERROR    entry                         Failed hdpost 2022-05-10 (Sign_in=> Url: https://pt.hdpost.top/pages/1 redirect to https://pt.hdpost.top)
2022-05-10 19:39:45 INFO     task                          Plugin retry_failed has requested task to be ran again after execution has completed.
2022-05-10 19:39:45 VERBOSE  task                          FAILED: `hdpost 2022-05-10` by auto_sign_in plugin because sign_in=> Url: https://pt.hdpost.top/pages/1 redirect to https://pt.hdpost.top
```