### PR TITLE
Avoid unnecessarily requesting a webpage twice when using a password to login

### DIFF
--- a/ptsites/schema/luminance.py
+++ b/ptsites/schema/luminance.py
@@ -98,7 +98,7 @@ class Luminance(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login',

--- a/ptsites/schema/xwt.py
+++ b/ptsites/schema/xwt.py
@@ -64,7 +64,7 @@ class XWT(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/takelogin.php',

--- a/ptsites/sites/abn.py
+++ b/ptsites/sites/abn.py
@@ -96,7 +96,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/Home/Login?ReturnUrl=%2F',

--- a/ptsites/sites/abtorrents.py
+++ b/ptsites/sites/abtorrents.py
@@ -14,7 +14,7 @@ class MainClass(XBT):
         'days': [90],
     }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login.php?returnto=%2F',

--- a/ptsites/sites/bootytape.py
+++ b/ptsites/sites/bootytape.py
@@ -105,7 +105,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login.php',

--- a/ptsites/sites/femdomcult.py
+++ b/ptsites/sites/femdomcult.py
@@ -10,7 +10,7 @@ class MainClass(Luminance):
         'days': [56]
     }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login.php',

--- a/ptsites/sites/filelist.py
+++ b/ptsites/sites/filelist.py
@@ -31,7 +31,7 @@ class MainClass(Ocelot):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login.php',

--- a/ptsites/sites/gay-torrents_net.py
+++ b/ptsites/sites/gay-torrents_net.py
@@ -75,7 +75,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login.php?do=login',
@@ -83,7 +83,11 @@ class MainClass(SiteBase):
                 succeed_regex=r'Thank you for logging in, .*?\.</p>',
                 check_state=('network', NetworkState.SUCCEED),
                 response_urls=['/login.php?do=login']
-            ),
+            )
+        ]
+
+    def build_workflow(self, entry, config):
+        return [
             Work(
                 url='/latest/',
                 method='get',

--- a/ptsites/sites/gaytor.py
+++ b/ptsites/sites/gaytor.py
@@ -82,7 +82,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/takelogin.php',

--- a/ptsites/sites/hdpost.py
+++ b/ptsites/sites/hdpost.py
@@ -75,9 +75,9 @@ class MainClass(Unit3D):
                 url='/',
                 method='get',
                 succeed_regex=('<a class="top-nav__username" href="https://pt.hdpost.top/users/(.*?)">', 1),
-                fail_regex=None,
                 check_state=('final', SignState.SUCCEED),
-                is_base_content=True
+                is_base_content=True,
+                response_urls=['', '/']
             )
         ]
 

--- a/ptsites/sites/m-team.py
+++ b/ptsites/sites/m-team.py
@@ -35,7 +35,7 @@ class MainClass(NexusPHP):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/takelogin.php',

--- a/ptsites/sites/milkie.py
+++ b/ptsites/sites/milkie.py
@@ -64,7 +64,7 @@ class MainClass(SiteBase):
             },
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/api/v1/auth/sessions',

--- a/ptsites/sites/ninjacentral.py
+++ b/ptsites/sites/ninjacentral.py
@@ -49,7 +49,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login',

--- a/ptsites/sites/ourbits.py
+++ b/ptsites/sites/ourbits.py
@@ -1,5 +1,4 @@
 from ..schema.nexusphp import AttendanceHR
-
 from ..schema.site_base import Work, NetworkState
 from ..utils.google_auth import GoogleAuth
 

--- a/ptsites/sites/pussytorrents.py
+++ b/ptsites/sites/pussytorrents.py
@@ -71,7 +71,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/user/account/login/',

--- a/ptsites/sites/speedapp.py
+++ b/ptsites/sites/speedapp.py
@@ -113,7 +113,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/zh/%E7%99%BB%E5%BD%95?locale=zh',

--- a/ptsites/sites/torrentdb.py
+++ b/ptsites/sites/torrentdb.py
@@ -84,7 +84,7 @@ class MainClass(SiteBase):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login',

--- a/ptsites/sites/torrentseeds.py
+++ b/ptsites/sites/torrentseeds.py
@@ -30,7 +30,7 @@ class MainClass(Unit3D):
             }
         }
 
-    def build_workflow(self, entry, config):
+    def build_login_workflow(self, entry, config):
         return [
             Work(
                 url='/login',

--- a/ptsites/utils/net_utils.py
+++ b/ptsites/utils/net_utils.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse, parse_qsl, unquote_plus
 
 import chardet
 
@@ -52,3 +53,9 @@ class NetUtils:
                 if site_name == 'edu':
                     site_name = domain[len(domain) - 3]
                 return site_name
+
+    @staticmethod
+    def url_equal(url1, url2):
+        parse = lambda url: (parsed := urlparse(url))._replace(query=frozenset(parse_qsl(parsed.query)),
+                                                               path=unquote_plus(parsed.path).rstrip('/'))
+        return parse(url1) == parse(url2)


### PR DESCRIPTION
目前，对本项目同时支持密码与cookie登录的网站使用密码登录时会执行`build_login_workflow()`和`build_workflow()`，但是在`build_login_workflow()`中发送了`post`请求登录后，该请求会被重定向至首页，因此不需要重复执行`build_workflow()`中的`get`请求了。

以hdpost举例，`build_login_workflow()`中的第2个`Work`在最终重定向后就`get`了首页，而无需再执行`build_workflow()`中的`get`请求了。
https://github.com/madwind/flexget_qbittorrent_mod/blob/856949a16ed07061f6448f0aee05058098fcb613/ptsites/sites/hdpost.py#L55-L82

本PR使得在使用密码登录时只执行`build_login_workflow()`而不执行`build_workflow()`，解决了该问题