### PR TITLE
Remove USER_CLASSES in XBTIT

### DIFF
--- a/ptsites/schema/xbtit.py
+++ b/ptsites/schema/xbtit.py
@@ -1,7 +1,6 @@
 import re
 from abc import ABC, abstractmethod
 from datetime import date
-from typing import Final
 from urllib.parse import urljoin
 
 from dateutil.parser import parse
@@ -19,12 +18,6 @@ class XBTIT(PrivateTorrent, ABC):
     @abstractmethod
     def SUCCEED_REGEX(self) -> str:
         pass
-
-    USER_CLASSES: Final = {
-        'uploaded': [8796093022208],
-        'share_ratio': [5.5],
-        'days': [70]
-    }
 
     def sign_in_build_workflow(self, entry: SignInEntry, config: dict) -> list[Work]:
         return [


### PR DESCRIPTION
`XBTIT`的4个子类（sportscult、hd-torrents、hd-space、gay-torrents_org）都定义了自已的`USER_CLASSES`，且各不相同。故无需在`XBTIT`中定义该属性。